### PR TITLE
add ALE compiler to the discovery

### DIFF
--- a/discovery/gemoc_3.1.x/catalog.md
+++ b/discovery/gemoc_3.1.x/catalog.md
@@ -185,6 +185,28 @@ Extensions for GEMOC Engines
     </div>
 </div>
 
+<!-- ALE compiler  -->
+<div class="row">    
+    <div class="col-md-8 col-md-push-4">    	
+        <h3><img src="images/IconeGemoc_studio-32.png" alt="">
+        ALE compiler <small>by Inria</small></h3>
+        <p>ALE compiler generates java code from ALE language.</p>
+        <p>The main features of the ALE Compiler are:</p><ul>
+		    <li>Integration with Eclipse: Compile ALE languages in the Eclipse IDE</li>
+		    <li>Maven integration: Automatically compile your languages using the ale compiler maven plugin</li>
+		    <li>Configurable: The ALE Compiler can target four implementation patterns: Interpreter, Visitor, EMF’s Switch and Revisitor.</li>
+		</ul>        
+		<p><a href="http://gemoc.org/ale-lang-compiler/">Learn more</a></p>
+        <h4>Update site</h4>
+        <ul>
+            <li><a href="http://www.kermeta.org/ale-lang-compiler/updates/">http://www.kermeta.org/ale-lang-compiler/updates/</a></li>            
+        </ul>
+    </div>
+    <div class="col-md-4 col-md-pull-8">
+       <!-- <img class="img-responsive img-hover" src="images/MCL_MBILang-screenshot.png" alt=""> -->        
+    </div>
+</div>
+
 <hr>
 ## Alternative GEMOC based Engines
 Engines and tools proposing alternative approaches (based on GEMOC execution framework)

--- a/discovery/gemoc_3.1.x/catalog.xmi
+++ b/discovery/gemoc_3.1.x/catalog.xmi
@@ -126,6 +126,20 @@
           url=""/>
       <id>fr.inria.glose.mcl.all.feature</id>
     </components>
+    <components
+        name="ALE compiler (Incubation)"
+        provider="Inria"
+        description="ALE compiler generates java code from ALE language.  [gemoc-studio 3.2.x]"
+        license="EPL"
+        groups="//@filters.0"
+        image32="images/IconeGemoc_studio-32.png">
+      <sitesURLS>http://www.kermeta.org/ale-lang-compiler/updates/2019-11-29/</sitesURLS>
+      <overview
+          summary="The main features of the ALE Compiler are:&#xA;    Integration with Eclipse: Compile ALE languages in the Eclipse IDE&#xA;    Maven integration: Automatically compile your languages using the ale compiler maven plugin&#xA;    Configurable: The ALE Compiler can target four implementation patterns: Interpreter, Visitor, EMF&#x2019;s Switch and Revisitor.&#xA;"
+          screenshot=""
+          url="http://gemoc.org/ale-lang-compiler/"/>
+      <id>fr.inria.glose.mcl.all.feature</id>
+    </components>
   </categories>
   <categories
       name="Alternative GEMOC based Engines"


### PR DESCRIPTION
This PR adds the ALE compiler update site to the GEMOC Studio discovery catalog

Signed-off-by: Didier Vojtisek <didier.vojtisek@inria.fr>